### PR TITLE
Fix Requests with asins and list ordering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,12 @@ PATH
       activesupport (~> 3.0)
       builder
       httparty (~> 0.11.0)
-      nokogiri (~> 1.5.0)
+      nokogiri (~> 1.6.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.14)
+    activesupport (3.2.17)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     builder (3.2.2)
@@ -30,16 +30,18 @@ GEM
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    i18n (0.6.5)
+    i18n (0.6.9)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     lumberjack (1.0.4)
     method_source (0.8.2)
-    multi_json (1.8.0)
+    mini_portile (0.5.2)
+    multi_json (1.9.0)
     multi_xml (0.5.5)
-    nokogiri (1.5.10)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)

--- a/lib/mws-rb/api/base.rb
+++ b/lib/mws-rb/api/base.rb
@@ -11,9 +11,17 @@ module MWS
       def call(action, params={})
         @verb = params.delete(:verb) || @verb
 
-        #extract request_params for feeds api requests
+        # extract request_params for feeds api requests
         request_params = params[:request_params] || {}
         params = params.except(:request_params)
+
+        # asin needs to be capitalized in requests
+        if action.to_s.include?("ASIN")
+          action = action.to_s.camelize
+          action.sub! "Asin", "ASIN"
+        else
+          action = action.to_s.camelize
+        end
 
         query = Query.new({
           verb: @verb,
@@ -23,7 +31,7 @@ module MWS
           aws_access_key_id: @connection.aws_access_key_id,
           aws_secret_access_key: @connection.aws_secret_access_key,
           seller_id: @connection.seller_id,
-          action: action.to_s.camelize,
+          action: action,
           version: @version,
           params: params
         })

--- a/lib/mws-rb/query.rb
+++ b/lib/mws-rb/query.rb
@@ -45,12 +45,20 @@ module MWS
       }
       query["Signature"] = signature if signature
 
-      params = Helpers.camelize_keys(@params || {})
-      params = Helpers.make_structured_lists(params)
+      params = Helpers.make_structured_lists(@params || {})
+      params = Helpers.camelize_keys(params)
       query.merge!(params)
 
-      # Sort hash in natural-byte order
-      Hash[Helpers.escape_date_time_params(query).sort].to_query
+      # http://jamesmurty.com/2008/12/31/aws-query-signature-version-2/
+      # Sort, and encode parameters into a canonical string.
+      sorted_params = Hash[Helpers.escape_date_time_params(query).sort { |x,y| x[0] <=> y[0] }]
+      encoded_params = sorted_params.collect do |p|
+        encoded = (CGI::escape(p[0].to_s) +
+                   "=" + CGI::escape(p[1].to_s))
+        # Ensure spaces are encoded as '%20', not '+'
+        encoded.gsub('+', '%20')
+      end
+      params_string = encoded_params.join("&")
     end
 
     module Helpers

--- a/mws-rb.gemspec
+++ b/mws-rb.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard-rspec"
 
   s.add_dependency 'httparty',      '~> 0.11.0'
-  s.add_dependency 'nokogiri',      '~> 1.5.0'
+  s.add_dependency 'nokogiri',      '~> 1.6.0'
   s.add_dependency 'activesupport', '~> 3.0'
   s.add_dependency 'builder'
 end

--- a/mws-rb.gemspec
+++ b/mws-rb.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty',      '~> 0.11.0'
   s.add_dependency 'nokogiri',      '~> 1.6.0'
-  s.add_dependency 'activesupport', '~> 3.0'
+  s.add_dependency 'activesupport', '~> 4.0'
   s.add_dependency 'builder'
 end


### PR DESCRIPTION
This pull request fixes requests with asins (i.e. GetLowestOfferListingsForASIN) and the usage of lists.

The word "ASIN" ned to be capitalised in requests.
```ruby
mws.products.call(:get_lowest_offer_listings_for_ASIN, params=params)
```
...resolves now to "GetLowestOfferListingsForASIN" and not "GetLowestOfferListingsForAsin".

---

The active record Hash#to_query broke the natural-byte order of the parameters.
```ruby
[ASINList.ASIN.10, ASINList.ASIN.12, ASINList.ASIN.1]
```
...gets not correctly reordered to: 
```ruby
[ ASINList.ASIN.1, ASINList.ASIN.10, ASINList.ASIN.12] 
```

