### PR TITLE
Added text based feeds feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,15 @@ PATH
   remote: .
   specs:
     mws-rb (0.0.1)
-      activesupport (= 4.0.8)
+      activesupport (~> 4.0.3)
       builder
-      httparty (~> 0.11.0)
-      nokogiri (~> 1.5.0)
+      httparty (~> 0.13.0)
+      nokogiri (~> 1.6.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (4.0.8)
+    activesupport (4.0.12)
       i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
       multi_json (~> 1.3)
@@ -30,20 +30,23 @@ GEM
     guard-rspec (3.0.3)
       guard (>= 1.8)
       rspec (~> 2.13)
-    httparty (0.11.0)
-      multi_json (~> 1.0)
+    httparty (0.13.3)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.6.11)
+    json (1.8.1)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     lumberjack (1.0.4)
     method_source (0.8.2)
+    mini_portile (0.6.1)
     minitest (4.7.5)
     multi_json (1.10.1)
     multi_xml (0.5.5)
-    nokogiri (1.5.11)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     mws-rb (0.0.1)
-      activesupport (~> 3.0)
+      activesupport (= 4.0.8)
       builder
       httparty (~> 0.11.0)
       nokogiri (~> 1.5.0)
@@ -10,9 +10,12 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.14)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.0.8)
+      i18n (~> 0.6, >= 0.6.9)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
     builder (3.2.2)
     coderay (1.0.9)
     diff-lcs (1.2.4)
@@ -30,16 +33,17 @@ GEM
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    i18n (0.6.5)
+    i18n (0.6.11)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     lumberjack (1.0.4)
     method_source (0.8.2)
-    multi_json (1.8.0)
+    minitest (4.7.5)
+    multi_json (1.10.1)
     multi_xml (0.5.5)
-    nokogiri (1.5.10)
+    nokogiri (1.5.11)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -59,6 +63,8 @@ GEM
     rspec-mocks (2.14.3)
     slop (3.4.6)
     thor (0.18.1)
+    thread_safe (0.3.4)
+    tzinfo (0.3.42)
 
 PLATFORMS
   ruby

--- a/lib/mws-rb/api/feeds/envelope.rb
+++ b/lib/mws-rb/api/feeds/envelope.rb
@@ -1,6 +1,12 @@
 class MWS::API::Feeds::Envelope
   def initialize(params={})
-    @envelope = build_envelope(params)
+    unless params[:type] == 'text'
+      @type = :xml
+      @envelope = build_envelope(params)
+    else
+      @type = :text
+      @envelope = params[:message]
+    end
     validate! unless params[:skip_schema_validation] == true
   end
 
@@ -23,11 +29,15 @@ class MWS::API::Feeds::Envelope
   end
 
   def to_s
-    result = @envelope.target!
-    result.gsub!('<Items type="array">', "")
-    result.gsub!('</Items>', "")
-    result.gsub!('<Inventories type="array">', "")
-    result.gsub!('</Inventories>', "")
+    if @type == :text
+      result = @envelope 
+    else
+      result = @envelope.target!
+      result.gsub!('<Items type="array">', "")
+      result.gsub!('</Items>', "")
+      result.gsub!('<Inventories type="array">', "")
+      result.gsub!('</Inventories>', "")
+    end
     result
   end
 
@@ -40,6 +50,7 @@ class MWS::API::Feeds::Envelope
   end
 
   private
+
   def build_envelope(params={})
     xml = Builder::XmlMarkup.new
     xml.instruct!

--- a/lib/mws-rb/query.rb
+++ b/lib/mws-rb/query.rb
@@ -29,7 +29,7 @@ module MWS
     end
 
     def signature
-      digest = OpenSSL::Digest::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
       Base64.encode64(OpenSSL::HMAC.digest(digest, aws_secret_access_key, canonical)).strip
     end
 

--- a/mws-rb.gemspec
+++ b/mws-rb.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty',      '~> 0.11.0'
   s.add_dependency 'nokogiri',      '~> 1.5.0'
-  s.add_dependency 'activesupport', '~> 3.0'
+  s.add_dependency 'activesupport', '4.0.8'
   s.add_dependency 'builder'
 end

--- a/mws-rb.gemspec
+++ b/mws-rb.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-rspec"
 
-  s.add_dependency 'httparty',      '~> 0.11.0'
-  s.add_dependency 'nokogiri',      '~> 1.5.0'
-  s.add_dependency 'activesupport', '4.0.8'
+  s.add_dependency 'httparty',      '~> 0.13.0'
+  s.add_dependency 'nokogiri',      '~> 1.6.0'
+  s.add_dependency 'activesupport', "~> 4.0.3"
   s.add_dependency 'builder'
 end


### PR DESCRIPTION
I have added a feature to the api, that will allow us to send text based (tab delimited) feeds to Amazon. 

So you can send new_feeds, quantity_and_price feeds, refunds_feeds, order_confirmation feeds etc
Also added Digest instead of Digest::Digest  (Digest::Digest is deprecated) in the lib/mws-rb/query.rb