### PR TITLE
Update order API version

### DIFF
--- a/lib/mws-rb/api/orders.rb
+++ b/lib/mws-rb/api/orders.rb
@@ -5,8 +5,8 @@ module MWS
                  :list_order_items_by_next_token, :get_service_status]
 
       def initialize(connection)
-        @uri = "/Orders/2011-01-01"
-        @version = "2011-01-01"
+        @uri = "/Orders/2013-09-01"
+        @version = "2013-09-01"
         @verb = :post
         super
       end


### PR DESCRIPTION
Version 2011-01-01 of the Orders API is being deprecated in favor of the new 2013-09-01 version.