### PR TITLE
Add global reference to the location of XSD files

### DIFF
--- a/lib/mws-rb/api/feeds.rb
+++ b/lib/mws-rb/api/feeds.rb
@@ -1,6 +1,8 @@
 module MWS
   module API
     class Feeds < Base
+      XSD_PATH = File.join(File.dirname(__FILE__), "feeds", "xsd")
+
       Actions = [:get_feed_submission_list, :get_feed_submission_list_by_next_token,
                  :get_feed_submission_count, :cancel_feed_submissions, :get_feed_submission_result ]
 

--- a/lib/mws-rb/api/feeds/envelope.rb
+++ b/lib/mws-rb/api/feeds/envelope.rb
@@ -32,7 +32,7 @@ class MWS::API::Feeds::Envelope
   end
 
   def xsd
-    Nokogiri::XML::Schema(File.open(File.join(File.dirname(__FILE__),"xsd/amzn-envelope.xsd")))
+    Nokogiri::XML::Schema(File.open(File.join(MWS::API::Feeds::XSD_PATH, "amzn-envelope.xsd")))
   end
 
   def errors


### PR DESCRIPTION
Allows to access XSD files easily.

Currently mws-rb uses XSD files for validation purposes, however there is more possibilities. For example for XML bindings or simply extract certain information.

Having those accessible makes life simpler ;)

Thank you!