### PR TITLE
Support for text based feeds

### DIFF
--- a/lib/mws-rb/api/feeds/envelope.rb
+++ b/lib/mws-rb/api/feeds/envelope.rb
@@ -1,6 +1,12 @@
 class MWS::API::Feeds::Envelope
   def initialize(params={})
-    @envelope = build_envelope(params)
+    unless params[:type] == 'text'
+      @type = :xml
+      @envelope = build_envelope(params)
+    else
+      @type = :text
+      @envelope = params[:message]
+    end
     validate! unless params[:skip_schema_validation] == true
   end
 
@@ -23,11 +29,15 @@ class MWS::API::Feeds::Envelope
   end
 
   def to_s
-    result = @envelope.target!
-    result.gsub!('<Items type="array">', "")
-    result.gsub!('</Items>', "")
-    result.gsub!('<Inventories type="array">', "")
-    result.gsub!('</Inventories>', "")
+    if @type == :text
+      result = @envelope 
+    else
+      result = @envelope.target!
+      result.gsub!('<Items type="array">', "")
+      result.gsub!('</Items>', "")
+      result.gsub!('<Inventories type="array">', "")
+      result.gsub!('</Inventories>', "")
+    end
     result
   end
 
@@ -40,6 +50,7 @@ class MWS::API::Feeds::Envelope
   end
 
   private
+
   def build_envelope(params={})
     xml = Builder::XmlMarkup.new
     xml.instruct!

--- a/lib/mws-rb/api/feeds/envelope.rb
+++ b/lib/mws-rb/api/feeds/envelope.rb
@@ -7,7 +7,7 @@ class MWS::API::Feeds::Envelope
       @type = :text
       @envelope = params[:message]
     end
-    validate! unless params[:skip_schema_validation] == true
+    validate! unless params[:skip_schema_validation] or @type == :text
   end
 
   def valid?


### PR DESCRIPTION
Cherry picked e48bec255cff1bd7ed2c75804525d077666ae700 from PR #9 which works fine with AS > 3.0

Here is usage example:

    mws_api = MWS.new(
      host: "mws-eu.amazonservices.com",
      aws_access_key_id: "Your access key id",
      aws_secret_access_key: "Your secret access key",
      seller_id: "Your seller/merchant id"
    )

    mws_api.feeds.submit_feed({
      feed_type: "_POST_FLAT_FILE_INVLOADER_DATA_",
      type: 'text',
      # message: File.read('./Flat.File.csv')
      message: "sku\tquantity\n375543813\t9"
    })

In other words it allows to upload data based on "Text-File Templates" weather it is a string or a file.

Also take into account that there is different list of feed types for the text based feeds:
http://docs.developer.amazonservices.com/en_US/feeds/Feeds_FeedType.html