### PR TITLE
Relax gem dependency on ActiveSupport

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # mws_rb
 
+[![Build Status](https://secure.travis-ci.org/veeqo/mws-rb.png)](http://travis-ci.org/veeqo/mws-rb)
+
 This gem is a complete wrapper for Amazon.com's Marketplace Web Service (MWS) API extracted from http://veeqo.com
 
 ## Installation

--- a/lib/mws.rb
+++ b/lib/mws.rb
@@ -2,6 +2,7 @@
 require 'httparty'
 require 'base64'
 require 'openssl'
+require 'active_support'
 require 'active_support/core_ext'
 require 'builder'
 require 'nokogiri'

--- a/mws_rb.gemspec
+++ b/mws_rb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty',      '~> 0.13'
   s.add_dependency 'nokogiri',      '~> 1.6'
-  s.add_dependency 'activesupport', '>= 3.0', '< 4.1'
+  s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'addressable',   '~> 2.3'
   s.add_dependency 'builder',       '~> 3.1'
 end


### PR DESCRIPTION
Tests passed for the following versions:

* 4.0.13
* 4.1.15
* 4.2.6