### PR TITLE
Add ability to add xml element attributes of `messages`

### DIFF
--- a/lib/mws/api/feeds/envelope.rb
+++ b/lib/mws/api/feeds/envelope.rb
@@ -1,3 +1,5 @@
+require 'xmlsimple'
+
 module MWS
   module API
     class Feeds
@@ -35,9 +37,9 @@ module MWS
             result = @envelope
           else
             result = @envelope.target!
-            result.gsub!('<Items type="array">', '')
+            result.gsub!('<Items>', '')
             result.gsub!('</Items>', '')
-            result.gsub!('<Inventories type="array">', '')
+            result.gsub!('<Inventories>', '')
             result.gsub!('</Inventories>', '')
           end
           result
@@ -76,7 +78,14 @@ module MWS
         end
 
         def message_xml(message)
-          message.to_xml(skip_instruct: true, root: 'Message')
+          options = {
+            'AttrPrefix' => true,
+            'RootName' => 'Message',
+            'XmlDeclaration' => false,
+            'KeepRoot' => true,
+            'GroupTags' => { 'Items' => 'Item', 'Inventories' => 'Inventory' }
+          }
+          XmlSimple.xml_out(message, options)
         end
       end
     end

--- a/mws_rb.gemspec
+++ b/mws_rb.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'addressable',   '~> 2.3'
   s.add_dependency 'builder',       '~> 3.1'
+  s.add_dependency 'xml-simple',    '~> 1.1'
 end

--- a/spec/mws-rb/api/feeds/envelope/xml_building_spec.rb
+++ b/spec/mws-rb/api/feeds/envelope/xml_building_spec.rb
@@ -57,6 +57,35 @@ describe MWS::API::Feeds::Envelope, 'built xml' do
     end
   end
 
+  context "when passed 'messages' param contains element with array value" do
+    let(:params) do
+      {
+        merchant_id: 'A28GO50DFGJ0C3',
+        feed_type: '_POST_ORDER_ACKNOWLEDGEMENT_DATA_',
+        message_type: :order_acknowledgement,
+        messages: {
+          "MessageID" => '123123123',
+          "OrderAcknowledgement" => {
+            "AmazonOrderID" => '123-1234567-1234567',
+            "StatusCode" => "Failure",
+            "Items" => [
+              { "AmazonOrderItemCode" => '12345678901234', "CancelReason" => "BuyerCanceled" },
+              { "AmazonOrderItemCode" => '12345678909876', "CancelReason" => "CustomerReturn" }
+            ]
+          }
+        }
+      }
+    end
+
+    it 'should contain passed data' do
+      expect(subject.to_s).to eq("<AmazonEnvelope><Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier>A28GO50DFGJ0C3</MerchantIdentifier></Header><MessageType>OrderAcknowledgement</MessageType><PurgeAndReplace>false</PurgeAndReplace><Message>\n  <MessageID>123123123</MessageID>\n  <OrderAcknowledgement>\n    <AmazonOrderID>123-1234567-1234567</AmazonOrderID>\n    <StatusCode>Failure</StatusCode>\n    \n      <Item>\n        <AmazonOrderItemCode>12345678901234</AmazonOrderItemCode>\n        <CancelReason>BuyerCanceled</CancelReason>\n      </Item>\n      <Item>\n        <AmazonOrderItemCode>12345678909876</AmazonOrderItemCode>\n        <CancelReason>CustomerReturn</CancelReason>\n      </Item>\n    \n  </OrderAcknowledgement>\n</Message>\n</AmazonEnvelope>")
+    end
+
+    it 'should be valid' do
+      expect(subject).to be_valid
+    end
+  end
+
   context 'when passed \'message\' and \'messages\'' do
     let(:multiple_messages) do
       { messages: [
@@ -96,6 +125,40 @@ describe MWS::API::Feeds::Envelope, 'built xml' do
       expect(subject.to_s).to include("<Message>\n  <MessageID>123123123</MessageID>\n  <OperationType>Update</OperationType>\n  <Inventory>\n    <SKU>ANY-SKU</SKU>\n    <Quantity>50</Quantity>\n  </Inventory>\n</Message>")
       expect(subject.to_s).to include("<Message>\n  <MessageID>321321321</MessageID>\n  <OperationType>Update</OperationType>\n  <Inventory>\n    <SKU>ANY-OTHER-SKU</SKU>\n    <Quantity>10</Quantity>\n  </Inventory>\n</Message>")
       expect(subject.to_s).to include("<Message>\n  <MessageID>987654321</MessageID>\n  <OperationType>Update</OperationType>\n  <Inventory>\n    <SKU>SINGLE-SKU</SKU>\n    <Quantity>20</Quantity>\n  </Inventory>\n</Message>")
+    end
+  end
+
+  context "when passed 'messages' param element require some attributes" do
+    let(:params) do
+      {
+        feed_type: '_POST_PRODUCT_PRICING_DATA_',
+        message_type: :price,
+        messages: [
+          {
+            'MessageID' => '123123123',
+            'OperationType' => 'Update',
+            'Price' => {
+              'SKU' => 'ANY-SKU',
+              'StandardPrice' => { '@currency' => 'USD', 'content' => '50' }
+            }
+          },
+          { 'MessageID' => '321321321',
+            'OperationType' => 'Update',
+            'Price' => {
+              'SKU' => 'ANY-OTHER-SKU',
+              'StandardPrice' => { '@currency' => 'USD', 'content' => '10' }
+            }
+          }
+        ]
+      }
+    end
+
+    it 'should contain passed data' do
+      expect(subject.to_s).to eq("<AmazonEnvelope><Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier/></Header><MessageType>Price</MessageType><PurgeAndReplace>false</PurgeAndReplace><Message>\n  <MessageID>123123123</MessageID>\n  <OperationType>Update</OperationType>\n  <Price>\n    <SKU>ANY-SKU</SKU>\n    <StandardPrice currency=\"USD\">50</StandardPrice>\n  </Price>\n</Message>\n<Message>\n  <MessageID>321321321</MessageID>\n  <OperationType>Update</OperationType>\n  <Price>\n    <SKU>ANY-OTHER-SKU</SKU>\n    <StandardPrice currency=\"USD\">10</StandardPrice>\n  </Price>\n</Message>\n</AmazonEnvelope>")
+    end
+
+    it 'should be valid' do
+      expect(subject).to be_valid
     end
   end
 end


### PR DESCRIPTION
Changes in this PR give you an ability to add `attribute` to xml element:
**Input:**
```Ruby
feed_data = {
  feed_type: "_POST_PRODUCT_PRICING_DATA_",
  message_type: :price,
  messages: { 
    'MessageID' => '321321321',
    'OperationType' => 'Update',
    'Price' => {
      'SKU' => 'ANY-OTHER-SKU',
      'StandardPrice' => { '@currency' => 'USD', 'content' => '10' }
    }
  }
}
mws_api.feeds.submit_feed(feed_data)
```

**Output:**
```xml
<AmazonEnvelope>
<Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier/></Header>
<MessageType>Price</MessageType>
<PurgeAndReplace>false</PurgeAndReplace>
<Message>
  <MessageID>321321321</MessageID>
  <OperationType>Update</OperationType>
  <Price>
    <SKU>ANY-OTHER-SKU</SKU>
    <StandardPrice currency="USD">10</StandardPrice>
  </Price>
</Message>
</AmazonEnvelope>
```