### PR TITLE
Add support for HTTParty versions up to 0.16

### DIFF
--- a/mws_rb.gemspec
+++ b/mws_rb.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr',           '~> 3.0'
   s.add_development_dependency 'webmock',       '~> 1.22'
 
-  s.add_dependency 'httparty',      '>= 0.13', '<= 0.16'
+  s.add_dependency 'httparty',      '>= 0.13'
   s.add_dependency 'nokogiri',      '~> 1.6'
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'addressable',   '~> 2.3'

--- a/mws_rb.gemspec
+++ b/mws_rb.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr',           '~> 3.0'
   s.add_development_dependency 'webmock',       '~> 1.22'
 
-  s.add_dependency 'httparty',      '~> 0.13'
+  s.add_dependency 'httparty',      '>= 0.13', '<= 0.16'
   s.add_dependency 'nokogiri',      '~> 1.6'
   s.add_dependency 'activesupport', '>= 3.0'
   s.add_dependency 'addressable',   '~> 2.3'


### PR DESCRIPTION
This adds support for versions of HTTParty between 0.13 and 0.16 (latest). The only breaking change in the newer versions is that it requires at least Ruby 2.0, but in which case 0.13 can be used if necessary.