### PR TITLE
Update OrderFulfillment envelope schema to the latest version

### DIFF
--- a/lib/mws/api/feeds/xsd/OrderFulfillment.xsd
+++ b/lib/mws/api/feeds/xsd/OrderFulfillment.xsd
@@ -53,7 +53,7 @@
                             </xsd:choice>
                             <xsd:element name="MerchantFulfillmentItemID" type="IDNumber" minOccurs="0"/>
                             <xsd:element name="Quantity" type="xsd:positiveInteger" minOccurs="0"/>
-                             <xsd:element name="TransparencyCode" type="xsd:string" minOccurs="0" maxOccurs="10"/>
+                            <xsd:element name="TransparencyCode" type="xsd:string" minOccurs="0" maxOccurs="10"/>
                         </xsd:sequence>
                     </xsd:complexType>
                 </xsd:element>

--- a/lib/mws/api/feeds/xsd/OrderFulfillment.xsd
+++ b/lib/mws/api/feeds/xsd/OrderFulfillment.xsd
@@ -6,9 +6,9 @@
     $Date: 2005/04/01 $
 
     AMAZON.COM CONFIDENTIAL.  This document and the information contained in it are
-    confidential and proprietary information of Amazon.com and may not be reproduced, 
-    distributed or used, in whole or in part, for any purpose other than as necessary 
-    to list products for sale on the www.amazon.com web site pursuant to an agreement 
+    confidential and proprietary information of Amazon.com and may not be reproduced,
+    distributed or used, in whole or in part, for any purpose other than as necessary
+    to list products for sale on the www.amazon.com web site pursuant to an agreement
     with Amazon.com.
     -->
 
@@ -36,6 +36,14 @@
                     </xsd:complexType>
                 </xsd:element>
 
+                <xsd:element name="CODCollectionMethod" minOccurs="0">
+                    <xsd:simpleType>
+                        <xsd:restriction base="xsd:string">
+                            <xsd:enumeration value="DirectPayment"/>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:element>
+
                 <xsd:element name="Item" minOccurs="0" maxOccurs="unbounded">
                     <xsd:complexType>
                         <xsd:sequence>
@@ -45,13 +53,14 @@
                             </xsd:choice>
                             <xsd:element name="MerchantFulfillmentItemID" type="IDNumber" minOccurs="0"/>
                             <xsd:element name="Quantity" type="xsd:positiveInteger" minOccurs="0"/>
+                             <xsd:element name="TransparencyCode" type="xsd:string" minOccurs="0" maxOccurs="10"/>
                         </xsd:sequence>
                     </xsd:complexType>
                 </xsd:element>
+                <xsd:element name="ShipFromAddress" type="AddressType" minOccurs="0" />
 
             </xsd:sequence>
         </xsd:complexType>
     </xsd:element>
 
 </xsd:schema>
-

--- a/spec/mws-rb/api/feeds/envelope/xml/feeds/order_fulfillment_spec.rb
+++ b/spec/mws-rb/api/feeds/envelope/xml/feeds/order_fulfillment_spec.rb
@@ -18,9 +18,10 @@ describe MWS::API::Feeds::Envelope, 'built _POST_ORDER_FULFILLMENT_DATA_ feed' d
               'ShippingMethod' => 'TruckDelivery',
               'ShipperTrackingNumber' => '123456789'
             },
+            'CODCollectionMethod' => 'DirectPayment',
             'Items' => [
-              { 'AmazonOrderItemCode' => '13131313131313', 'Quantity' => '1' },
-              { 'AmazonOrderItemCode' => '13131313131313', 'Quantity' => '2' }
+              { 'AmazonOrderItemCode' => '13131313131313', 'MerchantFulfillmentItemID' => '12345678912345', 'Quantity' => '1', 'TransparencyCode' => '123456789011' },
+              { 'AmazonOrderItemCode' => '13131313131313', 'MerchantFulfillmentItemID' => '12345678911111', 'Quantity' => '2', 'TransparencyCode' => '123456789012' }
             ],
             'ShipFromAddress' => {
               'Name' => 'Berlin Address',
@@ -40,7 +41,7 @@ describe MWS::API::Feeds::Envelope, 'built _POST_ORDER_FULFILLMENT_DATA_ feed' d
 
     it 'contains passed data' do
       expect(subject.to_s.squish).to include(
-        "<AmazonEnvelope><Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier/></Header><MessageType>OrderFulfillment</MessageType><PurgeAndReplace>false</PurgeAndReplace><Message> <MessageID>123123123</MessageID> <OrderFulfillment> <AmazonOrderID>123-3333333-4444444</AmazonOrderID> <FulfillmentDate>2020-12-08T15:23:47Z</FulfillmentDate> <FulfillmentData> <CarrierName>Other</CarrierName> <ShippingMethod>TruckDelivery</ShippingMethod> <ShipperTrackingNumber>123456789</ShipperTrackingNumber> </FulfillmentData> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <Quantity>1</Quantity> </Item> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <Quantity>2</Quantity> </Item> <ShipFromAddress> <Name>Berlin Address</Name> <AddressFieldOne>572 Brett Knolls</AddressFieldOne> <AddressFieldTwo>Apt. 064</AddressFieldTwo> <City>West Antoinebury</City> <StateOrRegion>Kent</StateOrRegion> <PostalCode>GA6 8HS</PostalCode> <CountryCode>GB</CountryCode> </ShipFromAddress> </OrderFulfillment> </Message> </AmazonEnvelope>"
+        "<AmazonEnvelope><Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier/></Header><MessageType>OrderFulfillment</MessageType><PurgeAndReplace>false</PurgeAndReplace><Message> <MessageID>123123123</MessageID> <OrderFulfillment> <AmazonOrderID>123-3333333-4444444</AmazonOrderID> <FulfillmentDate>2020-12-08T15:23:47Z</FulfillmentDate> <FulfillmentData> <CarrierName>Other</CarrierName> <ShippingMethod>TruckDelivery</ShippingMethod> <ShipperTrackingNumber>123456789</ShipperTrackingNumber> </FulfillmentData> <CODCollectionMethod>DirectPayment</CODCollectionMethod> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <MerchantFulfillmentItemID>12345678912345</MerchantFulfillmentItemID> <Quantity>1</Quantity> <TransparencyCode>123456789011</TransparencyCode> </Item> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <MerchantFulfillmentItemID>12345678911111</MerchantFulfillmentItemID> <Quantity>2</Quantity> <TransparencyCode>123456789012</TransparencyCode> </Item> <ShipFromAddress> <Name>Berlin Address</Name> <AddressFieldOne>572 Brett Knolls</AddressFieldOne> <AddressFieldTwo>Apt. 064</AddressFieldTwo> <City>West Antoinebury</City> <StateOrRegion>Kent</StateOrRegion> <PostalCode>GA6 8HS</PostalCode> <CountryCode>GB</CountryCode> </ShipFromAddress> </OrderFulfillment> </Message> </AmazonEnvelope>"
       )
     end
   end

--- a/spec/mws-rb/api/feeds/envelope/xml/feeds/order_fulfillment_spec.rb
+++ b/spec/mws-rb/api/feeds/envelope/xml/feeds/order_fulfillment_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe MWS::API::Feeds::Envelope, 'built _POST_ORDER_FULFILLMENT_DATA_ feed' do
+  subject { described_class.new(params) }
+
+  context 'when passed message param' do
+    let(:params) do
+      {
+        feed_type: '_POST_ORDER_FULFILLMENT_DATA_',
+        message_type: :order_fulfillment,
+        message: {
+          'MessageID' => '123123123',
+          'OrderFulfillment' => {
+            'AmazonOrderID' => '123-3333333-4444444',
+            'FulfillmentDate' => '2020-12-08T15:23:47Z',
+            'FulfillmentData' => {
+              'CarrierName' => 'Other',
+              'ShippingMethod' => 'TruckDelivery',
+              'ShipperTrackingNumber' => '123456789'
+            },
+            'Items' => [
+              { 'AmazonOrderItemCode' => '13131313131313', 'Quantity' => '1' },
+              { 'AmazonOrderItemCode' => '13131313131313', 'Quantity' => '2' }
+            ],
+            'ShipFromAddress' => {
+              'Name' => 'Berlin Address',
+              'AddressFieldOne' => '572 Brett Knolls',
+              'AddressFieldTwo' => 'Apt. 064',
+              'City' => 'West Antoinebury',
+              'StateOrRegion' => 'Kent',
+              'PostalCode' => 'GA6 8HS',
+              'CountryCode' => 'GB'
+            }
+          }
+        }
+      }
+    end
+
+    it { expect(subject).to be_valid }
+
+    it 'contains passed data' do
+      expect(subject.to_s.squish).to include(
+        "<AmazonEnvelope><Header><DocumentVersion>1.01</DocumentVersion><MerchantIdentifier/></Header><MessageType>OrderFulfillment</MessageType><PurgeAndReplace>false</PurgeAndReplace><Message> <MessageID>123123123</MessageID> <OrderFulfillment> <AmazonOrderID>123-3333333-4444444</AmazonOrderID> <FulfillmentDate>2020-12-08T15:23:47Z</FulfillmentDate> <FulfillmentData> <CarrierName>Other</CarrierName> <ShippingMethod>TruckDelivery</ShippingMethod> <ShipperTrackingNumber>123456789</ShipperTrackingNumber> </FulfillmentData> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <Quantity>1</Quantity> </Item> <Item> <AmazonOrderItemCode>13131313131313</AmazonOrderItemCode> <Quantity>2</Quantity> </Item> <ShipFromAddress> <Name>Berlin Address</Name> <AddressFieldOne>572 Brett Knolls</AddressFieldOne> <AddressFieldTwo>Apt. 064</AddressFieldTwo> <City>West Antoinebury</City> <StateOrRegion>Kent</StateOrRegion> <PostalCode>GA6 8HS</PostalCode> <CountryCode>GB</CountryCode> </ShipFromAddress> </OrderFulfillment> </Message> </AmazonEnvelope>"
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is to add support for the `ShipFromAddress` in the `_POST_ORDER_FULFILLMENT_DATA_` feed. But here we're also adding some test coverage to make sure the data is built correctly. We can use the same sort of structure for other feeds and requests.